### PR TITLE
Required plugin vagrant-env

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 Vagrant.configure("2") do |config|
+  config.vagrant.plugins = "vagrant-env" # Install plugin to support .env files
   config.env.enable # enable .env support plugin (it will let us easily enable cloud_init support)
 
   # Give a custom name for a VM created by this script for a Vagrant CLI


### PR DESCRIPTION
Prompt for installation of required 'vagrant-env' plugin automatically.

## Test config file
$ vagrant validate
==> vagrant: You have requested to enabled the experimental flag with the following features:
==> vagrant: 
==> vagrant: Features:  cloud_init, disks
==> vagrant: 
==> vagrant: Please use with caution, as some of the features may not be fully
==> vagrant: functional yet.
Vagrantfile validated successfully.

## Test run 
$ vagrant up 
Vagrant has detected project local plugins configured for this
project which are not installed.

  vagrant-env
Install local plugins (Y/N) [N]: y
Installing the 'vagrant-env' plugin. This can take a few minutes...
Fetching dotenv-deployment-0.0.2.gem
Fetching dotenv-0.11.1.gem
Fetching vagrant-env-0.0.3.gem
Installed the plugin 'vagrant-env (0.0.3)'!


Vagrant has completed installing local plugins for the current Vagrant
project directory. Please run the requested command again.

